### PR TITLE
Fixes issue 146: Update generate-tags script

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,11 +1,13 @@
 In alphabetical order:
 
   1. Fatima Villanueva (Kaira) <fzf.villanueva@gmail.com>
-  2. Jorge Arias <mail@jorgearias.cl>
-  3. Jose Zamudio <jose.zamudiobarrera@postgrad.manchester.ac.uk>
-  4. Kartik Arora <chipset95@yahoo.co.in>
-  5. Marcus Eisele <marcus.eisele@gmail.com>
-  6. Nathan Jaremkio <njaremko@gmail.com>
-  7. Panos Sakkos <panos.sakkos@protonmail.com>
-  8. Prashant Solanki <prs.solanki@live.com>
-  9. Sergey Lysenko <soulwish.ls@gmail.com>
+  1. Jorge Arias <mail@jorgearias.cl>
+  1. Jose Zamudio <jose.zamudiobarrera@postgrad.manchester.ac.uk>
+  1. Jørn Ølmheim <jorn@olmheim.com>
+  1. Kartik Arora <chipset95@yahoo.co.in>
+  1. Marcus Eisele <marcus.eisele@gmail.com>
+  1. Nathan Jaremkio <njaremko@gmail.com>
+  1. Panos Sakkos <panos.sakkos@protonmail.com>
+  1. Prashant Solanki <prs.solanki@live.com>
+  1. Sergey Lysenko <soulwish.ls@gmail.com>
+

--- a/scripts/generate-tags
+++ b/scripts/generate-tags
@@ -9,16 +9,18 @@ Dir.foreach(POSTS_DIR) do |post|
 
   next if post == '.' or post == '..' or post == '.DS_Store'
   postYaml = YAML.load_file(POSTS_DIR + post)
-  postYaml['tags'].each{|tag|
+  unless (postYaml['tags'] == nil)
+    postYaml['tags'].each{|tag|
 
-    unless File.exist?(TAGS_DIR + tag + '.html')
+      unless File.exist?(TAGS_DIR + tag + '.html')
 
-      puts('[+] Generating #' + tag + ' page')
+        puts('[+] Generating #' + tag + ' page')
 
-      File.open(TAGS_DIR + tag + '.html', 'w') {|f| f.write(
-      "---\nlayout: tag\nsection-type: tag\ntitle: " + tag + "\n---\n## Tag")}
+        File.open(TAGS_DIR + tag + '.html', 'w') {|f| f.write(
+        "---\nlayout: tag\nsection-type: tag\ntitle: " + tag + "\n---\n## Tag")}
 
-    end
-  }
+      end
+    }
+  end
 
 end


### PR DESCRIPTION
Fixed bug when posts do not have tags. Script will now happily run as long as the tags field is present in the yaml preamble.