### PR TITLE
Removed case-sensitive tag page creation

### DIFF
--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -20,9 +20,12 @@
 
           <div>
             {% for post in site.posts %}
-              {% if post.tags contains tag %}
-                {% include post-list.html%}
-              {% endif %}
+              {% for t in post.tags %}
+                {% capture tg %}{{ t | downcase }}{% endcapture %}
+                {% if tg == tag %}
+                  {% include post-list.html%}
+                {% endif %}
+              {% endfor %}
             {% endfor %}
           </div>
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -5,4 +5,4 @@ title: Blog
 sitemap:
   priority: 1.0
 ---
-##Blog
+## Blog

--- a/scripts/generate-tags
+++ b/scripts/generate-tags
@@ -12,6 +12,8 @@ Dir.foreach(POSTS_DIR) do |post|
   unless (postYaml['tags'] == nil)
     postYaml['tags'].each{|tag|
 
+      tag.downcase!
+
       unless File.exist?(TAGS_DIR + tag + '.html')
 
         puts('[+] Generating #' + tag + ' page')


### PR DESCRIPTION
The string comparison to create the tag pages was case-sensitive. Changed this behavior so all posts with the corresponding tag are added to the tag-overview-page, independent of their capitalization.