### PR TITLE
Remove density member

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,38 +7,32 @@
     {
       "src": "{{site.baseurl}}{{site.icon-36p}}",
       "sizes": "36x36",
-      "type": "image/png",
-      "density": 0.75
+      "type": "image/png"
     },
     {
       "src": "{{site.baseurl}}{{site.icon-48p}}",
       "sizes": "48x48",
-      "type": "image/png",
-      "density": 1.0
+      "type": "image/png"
     },
     {
       "src": "{{site.baseurl}}{{site.icon-72p}}",
       "sizes": "72x72",
-      "type": "image/png",
-      "density": 1.5
+      "type": "image/png"
     },
     {
       "src": "{{site.baseurl}}{{site.icon-96p}}",
       "sizes": "96x96",
-      "type": "image/png",
-      "density": 2.0
+      "type": "image/png"
     },
     {
       "src": "{{site.baseurl}}{{site.icon-144p}}",
       "sizes": "144x144",
-      "type": "image/png",
-      "density": 3.0
+      "type": "image/png"
     },
     {
       "src": "{{site.baseurl}}{{site.icon-192p}}",
       "sizes": "192x192",
-      "type": "image/png",
-      "density": 4.0
+      "type": "image/png"
     }
   ],
   "start_url": "{{site.url}}{{site.baseurl}}",


### PR DESCRIPTION
Issue Fixed #171

## Proposed Changes
The density member was dropped from the W3C spec. Support has been removed from both Chrome and Firefox. 
See: https://github.com/w3c/manifest/issues/450

It is also incorrectly used in this manifest.