### PR TITLE
Fix Post Preview Strip HTML Bug

### DIFF
--- a/.github/CONTRIBUTORS.md
+++ b/.github/CONTRIBUTORS.md
@@ -8,7 +8,8 @@ In alphabetical order:
   6. Jørn Ølmheim <jorn@olmheim.com>
   7. Kartik Arora <chipset95@yahoo.co.in>
   8. Marcus Eisele <marcus.eisele@gmail.com>
-  9. Nathan Jaremkio <njaremko@gmail.com>
-  10. Panos Sakkos <panos.sakkos@protonmail.com>
-  11. Prashant Solanki <prs.solanki@live.com>
-  12. Sergey Lysenko <soulwish.ls@gmail.com>
+  9. Mike Kasberg <kasberg.mike@gmail.com>
+  10. Nathan Jaremkio <njaremko@gmail.com>
+  11. Panos Sakkos <panos.sakkos@protonmail.com>
+  12. Prashant Solanki <prs.solanki@live.com>
+  13. Sergey Lysenko <soulwish.ls@gmail.com>

--- a/_includes/latest-post.html
+++ b/_includes/latest-post.html
@@ -18,7 +18,7 @@
           <small> <a href="{{site.baseurl}}{{post.url}}#disqus_thread">Comments</a></small>
         </h4>
 
-        {{ post.content | truncatewords: site.post-preview-words | strip_html | markdownify }}
+        {{ post.content | strip_html | markdownify | truncatewords: site.post-preview-words }}
 
         <h4><a href="{{site.baseurl}}/blog/">View more posts</a></h4>
 


### PR DESCRIPTION
Issue Fixed #175 

## Before

![screenshot from 2016-05-28 15-27-22](https://cloud.githubusercontent.com/assets/12214617/15630138/a8b9e1b4-24eb-11e6-9cb4-ed22c942e23b.png)

## After

![screenshot from 2016-05-28 15-28-18](https://cloud.githubusercontent.com/assets/12214617/15630141/ae1d1a2c-24eb-11e6-812c-1364735daff8.png)

Fixes #175.

The post preview feature uses 3 filters: markdownify, strip_html, and
truncatewords. We need to do truncatewords last so we don't truncate in
the middle of a tag.