### PR TITLE
New scripts to serve across lan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/
 _deploy/*
 Rakefile
 .jekyll-metadata
+/.idea/

--- a/README.md
+++ b/README.md
@@ -87,15 +87,21 @@ The theme contains documentation in the form of [blog posts](https://panossakkos
 
 First, you need to install jekyll and the dependencies of { Personal } by running:
 
-````
+```shell
 ./scripts/install
-````
+```
 
 Then, you can build and serve your website by simply running:
 
-````
+```shell
 ./scripts/serve-production
-````
+```
+
+To serve across lan (requires su to forward the port 4000 over lan):
+
+```shell
+./scripts/serve-lan-production
+```
 
 ## Wiki
 

--- a/scripts/serve-lan
+++ b/scripts/serve-lan
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sudo iptables -I INPUT -p tcp --dport 4000 -j ACCEPT
+jekyll serve --watch --host "0.0.0.0" --baseurl ""

--- a/scripts/serve-lan-production
+++ b/scripts/serve-lan-production
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sudo iptables -I INPUT -p tcp --dport 4000 -j ACCEPT
+JEKYLL_ENV=production jekyll serve --host "0.0.0.0" --baseurl ""


### PR DESCRIPTION
## Proposed Changes

  - Made two new scripts, `serve-lan` and `serve-lan-production` to serve the site across enitre lan
  - Makes it easier to test on multiple devices connected on same network like mobiles, tablets, PCs, TVs etc.
  - Once hosted, on a browser open the lan IP of the device hosting the site with the port no **4000**, e.g. `192.168.1.6:4000`, `10.0.0.43:4000`, `172.16.88.194:4000`

