### PR TITLE
Fix links to tag page in blogposts when tag is not lowercase

### DIFF
--- a/.github/CONTRIBUTORS.md
+++ b/.github/CONTRIBUTORS.md
@@ -14,3 +14,4 @@ In alphabetical order:
   11. Panos Sakkos <panos.sakkos@protonmail.com>
   12. Prashant Solanki <prs.solanki@live.com>
   13. Sergey Lysenko <soulwish.ls@gmail.com>
+  14. Simon Böhm <simonboehm@gmx.de>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -27,7 +27,7 @@
               <a href="{{site.baseurl}}{{page.url }}#disqus_thread">Comments</a>
               <br />
               {% for tag in page.tags %}
-                <a class="tag" href="{{site.baseurl}}/tags/{{tag}}.html">#{{ tag }}</a>
+                <a class="tag" href="{{site.baseurl}}/tags/{{tag | downcase}}.html">#{{ tag }}</a>
               {% endfor %}
             </small>
           </h4>


### PR DESCRIPTION
The tag pages will have exactly the same name as specified in the blog post that created the tag. Before they were all lowercase, which broke some links.

### Example
Blog post with `tags: ['Tutorial']` would create subpage `tags/tutorial.html` but would link to `tags/Tutorial.html` resulting in the 404 page.

Issue Fixed #213 