### PR TITLE
Add `relative_url` and `absolute_url` filters to link to resoources references

### DIFF
--- a/_includes/blog.html
+++ b/_includes/blog.html
@@ -13,7 +13,7 @@
           .
           <a
             class="category"
-            href="{{site.url}}/categories/{{ post.category | downcase }}.html"
+            href="{{ '/categories/' | absolute_url }}{{ post.category | downcase }}.html"
           >
             {{ post.category }}
           </a>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,11 +19,11 @@
     crossorigin="anonymous"
     referrerpolicy="no-referrer"
   />
-  <link href="{{site.url}}/css/grayscale.css" rel="stylesheet" />
+  <link href="{{ '/css/grayscale.css' | relative_url }}" rel="stylesheet" />
 
   {% if page.layout == "post" %}
-  <link href="{{site.url}}/css/everforest.css" rel="stylesheet" />
-  <link href="{{site.url}}/css/rrssb.css" rel="stylesheet" />
+  <link href="{{ '/css/everforest.css' | relative_url }}" rel="stylesheet" />
+  <link href="{{ '/css/rrssb.css' | relative_url }}" rel="stylesheet" />
   {% endif %}
 
   <!-- Fonts -->

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -37,7 +37,7 @@
             {% else %}
           <a class="nav-link pe-2 ps-2" href="{{ '/blog/' | absolute_url }}">{{ p[0] }}</a>
             {% endif %} {% else %}
-          <a class="nav-link pe-2 ps-2" href="{{site.url}}/#{{ p[1] }}">{{ p[0] }}</a>
+          <a class="nav-link pe-2 ps-2" href="{{ '/#' | absolute_url }}{{ p[1] }}">{{ p[0] }}</a>
             {% endif %}
           </li>
           {% endfor %} 

--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -4,7 +4,7 @@
   <ul class="pagination justify-content-center">
     {% if paginator.previous_page %}
     <li class="page-item">
-      <a href="{{site.url}}/{{ paginator.previous_page_path }}" aria-label="Previous">
+      <a href="{{ paginator.previous_page_path | relative_url }}" aria-label="Previous">
         <span aria-hidden="true">&laquo; Newer Posts</span>
       </a>
     </li>
@@ -14,7 +14,7 @@
     </li>
     {% endif %} {% if paginator.next_page %}
     <li class="page-item">
-      <a href="{{site.url}}/{{ paginator.next_page_path }}" aria-label="Next">
+      <a href="{{ paginator.next_page_path | relative_url }}" aria-label="Next">
         <span aria-hidden="true">Older Posts &raquo;</span>
       </a>
     </li>

--- a/_includes/post-list.html
+++ b/_includes/post-list.html
@@ -4,7 +4,7 @@
   {{ post.date | date_to_string }}
   <small>
     .
-    <a class="category" href="{{site.url}}/categories/{{ post.category | downcase }}.html">
+    <a class="category" href="{{ '/categories/' | absolute_url }}{{ post.category | downcase }}.html">
       {{ post.category }}
     </a>
     .

--- a/_includes/timeline.html
+++ b/_includes/timeline.html
@@ -17,7 +17,7 @@
           <div class="timeline-image">
             <img
               class="rounded-circle img-fluid"
-              src="{{site.url}}/{{ event.image }}"
+              src="{{ event.image | relative_url }}"
               alt=""
               width="156"
               height="156"

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -17,7 +17,7 @@
               .
               <a
                 class="category"
-                href="{{site.url}}/categories/{{ page.category | downcase }}.html"
+                href="{{ '/categories/' | absolute_url }}{{ page.category | downcase }}.html"
               >
                 {{ page.category }}
               </a>
@@ -25,7 +25,7 @@
               <a href="{{ page.url }}#disqus_thread">Comments</a>
               <br />
               {% for tag in page.tags %}
-              <a class="tag" href="{{site.url}}/tags/{{ tag }}.html">#{{ tag }}</a>
+              <a class="tag" href="{{ '/tags/' | absolute_url }}{{ tag }}.html">#{{ tag }}</a>
               {% endfor %}
             </small>
           </h6>

--- a/feed.xml
+++ b/feed.xml
@@ -7,7 +7,7 @@ layout: null
 		<title>{{ site.title | xml_escape }}</title>
 		<description>{% if site.description %}{{ site.description | xml_escape }}{% endif %}</description>
 		<link>{{site.url}}</link>
-		<atom:link href="{{site.url}}/feed.xml" rel="self" type="application/rss+xml" />
+		<atom:link href="{{ 'feed.xml' | absolute_url }}" rel="self" type="application/rss+xml" />
 		{% for post in site.posts limit:10 %}
 			<item>
 				<title>{{post.title | xml_escape}}</title>


### PR DESCRIPTION
See more: https://jekyllrb.com/docs/liquid/filters/

Fixes le4ker/personal-jekyll-theme#273
