### PR TITLE
Fix link references using Jekyll filters instead of concatenation

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -61,7 +61,7 @@
         notice_banner_reject_button_hide: false,
         preferences_center_close_button_hide: false,
         page_refresh_confirmation_buttons: false,
-        website_name: "{{ site.url }}",
+        website_name: "{{ '/' | absolute_url }}",
       });
     });
   </script>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -4,7 +4,7 @@
   <div class="container">
     <a
       class="navbar-brand page-scroll"
-      href="{% if page.section-type == 'index' %}#page-top{% else %}{{site.url}}{% endif %}"
+      href="{% if page.section-type == 'index' %}#page-top{% else %}{{ '/' | absolute_url }}{% endif %}"
       aria-controls="navbarNav"
       aria-label="Collapse navigation"
     >

--- a/_layouts/error.html
+++ b/_layouts/error.html
@@ -682,7 +682,7 @@
           </svg>
           <p>
             The page you are looking for does not exist. How you got here is a
-            mystery. But you can click <a href="{{ site.url | absolute_url }}">here</a>
+            mystery. But you can click <a href="{{ '/' | absolute_url }}">here</a>
             to go back to the homepage.
           </p>
         </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -44,7 +44,7 @@
             <div class="col-4 col-sm-3 col-md-2">
               <img
                 class="img-fluid"
-                src="{{site.url}}{{ site.author_blurb_image }}"
+                src="{{ site.author_blurb_image | absolute_url }}"
                 alt="Me"
               />
             </div>

--- a/feed.xml
+++ b/feed.xml
@@ -6,7 +6,7 @@ layout: null
 	<channel>
 		<title>{{ site.title | xml_escape }}</title>
 		<description>{% if site.description %}{{ site.description | xml_escape }}{% endif %}</description>
-		<link>{{site.url}}</link>
+		<link>{{ "/" | absolute_url }}</link>
 		<atom:link href="{{ 'feed.xml' | absolute_url }}" rel="self" type="application/rss+xml" />
 		{% for post in site.posts limit:10 %}
 			<item>

--- a/manifest.json
+++ b/manifest.json
@@ -35,6 +35,6 @@
       "type": "image/png"
     }
   ],
-  "start_url": "{{site.url}}",
+  "start_url": "{{ '/' | absolute_url }}",
   "display": "standalone"
 }

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -35,7 +35,7 @@ layout: null
   {% endfor %}
   {% for tag in site.tags %}
     <url>
-      <loc>{{ site.url }}{{ site.baseurl }}/tags/{{ tag[0] }}.html</loc>
+      <loc>{{ "/tags/" | absolute_url }}{{ tag[0] }}.html</loc>
       <changefreq>weekly</changefreq>
       <priority>0.8</priority>
     </url>


### PR DESCRIPTION
See more: https://jekyllrb.com/docs/liquid/filters/
